### PR TITLE
[BUGFIX] Quando o mes de validade só tinha um caracter, apresentava um bug de estilo

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -224,7 +224,7 @@ const Card = ({
                                         key={cardMonth}
                                     >
                                         <span>
-                                            {!cardMonth ? 'MM' : cardMonth}{' '}
+                                            {!cardMonth ? 'MM' : (cardMonth.split('').length > 1 ? `0${cardMonth}` : cardMonth)}{' '}
                                         </span>
                                     </CSSTransition>
                                 </SwitchTransition>


### PR DESCRIPTION
# BUG
Quando se coloca um mes com apenas um caracter [1-9], apresentava um espaco em branco, o qual foi retirado e acrescentado um zero.

## BEFORE
![image](https://user-images.githubusercontent.com/57506257/203453861-8106f501-5a8f-48ea-8a9f-36c799ef78ae.png)


## AFTER

![image](https://user-images.githubusercontent.com/57506257/203453813-3f12bca7-b72d-4c34-9ec7-77176dc6f497.png)
